### PR TITLE
Refactor chisel

### DIFF
--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/ChiselModule.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/ChiselModule.java
@@ -9,6 +9,7 @@ import net.minecraft.item.crafting.IRecipe;
 import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
@@ -50,6 +51,10 @@ public class ChiselModule extends IntegrationSubmodule {
         ChiselToolItems.init();
     }
 
+    @Override
+    public void postInit(FMLPostInitializationEvent event) {
+        ChiselBlocksRecipe.registerAutoChiselRecipe();
+    }
 
     @SubscribeEvent
     public static void onRegisterItems(RegistryEvent.Register<Item> event) {

--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/metatileentities/ChiselMetaTileEntities.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/metatileentities/ChiselMetaTileEntities.java
@@ -2,7 +2,7 @@ package com.github.gtexpert.gtmoretools.integration.chisel.metatileentities;
 
 import static com.github.gtexpert.gtmoretools.api.util.ModUtility.id;
 import static gregtech.api.GTValues.*;
-import static gregtech.common.metatileentities.MetaTileEntities.registerMetaTileEntity;
+import static gregtech.common.metatileentities.MetaTileEntities.registerMetaTileEntities;
 
 import gregtech.api.util.GTUtility;
 
@@ -11,18 +11,15 @@ import com.github.gtexpert.gtmoretools.integration.chisel.ChiselRecipeMaps;
 
 public class ChiselMetaTileEntities {
 
-    public static MetaTileEntityAutoChisel[] AUTO_CHISEL = new MetaTileEntityAutoChisel[3];
+    public static MetaTileEntityAutoChisel[] AUTO_CHISEL = new MetaTileEntityAutoChisel[9]; // LV - UV
 
     public static void init() {
-        // Auto Chisel 11001~11003
-        AUTO_CHISEL[0] = registerMetaTileEntity(11001,
-                new MetaTileEntityAutoChisel(id("auto_chisel.lv"), ChiselRecipeMaps.AUTO_CHISEL_RECIPES,
-                        ModTextures.AUTO_CHISEL_OVERLAY, LV, true, GTUtility.defaultTankSizeFunction));
-        AUTO_CHISEL[1] = registerMetaTileEntity(11002,
-                new MetaTileEntityAutoChisel(id("auto_chisel.mv"), ChiselRecipeMaps.AUTO_CHISEL_RECIPES,
-                        ModTextures.AUTO_CHISEL_OVERLAY, MV, true, GTUtility.defaultTankSizeFunction));
-        AUTO_CHISEL[2] = registerMetaTileEntity(11003,
-                new MetaTileEntityAutoChisel(id("auto_chisel.hv"), ChiselRecipeMaps.AUTO_CHISEL_RECIPES,
-                        ModTextures.AUTO_CHISEL_OVERLAY, HV, true, GTUtility.defaultTankSizeFunction));
+        // Auto Chisel 11001~11008
+        registerMetaTileEntities(AUTO_CHISEL, 11001, "auto_chisel",
+                (tier, voltageName) -> new MetaTileEntityAutoChisel(
+                        id(String.format("%s.%s", "auto_chisel", voltageName)),
+                        ChiselRecipeMaps.AUTO_CHISEL_RECIPES,
+                        ModTextures.AUTO_CHISEL_OVERLAY,
+                        tier, true, GTUtility.defaultTankSizeFunction));
     }
 }

--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/metatileentities/MetaTileEntityAutoChisel.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/metatileentities/MetaTileEntityAutoChisel.java
@@ -1,9 +1,12 @@
 package com.github.gtexpert.gtmoretools.integration.chisel.metatileentities;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import net.minecraft.util.ResourceLocation;
 
+import gregtech.api.GTValues;
+import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
@@ -17,12 +20,21 @@ public class MetaTileEntityAutoChisel extends SimpleMachineMetaTileEntity {
     public MetaTileEntityAutoChisel(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap, ICubeRenderer renderer,
                                     int tier, boolean hasFrontFacing, Function<Integer, Integer> tankScalingFunction) {
         super(metaTileEntityId, recipeMap, renderer, tier, hasFrontFacing, tankScalingFunction);
-        new SingleblockRecipeLogicNoCache(this, recipeMap, () -> this.energyContainer);
+        new AutoChiselRecipeLogic(this, recipeMap, () -> this.energyContainer);
+        this.getRecipeLogic().setParallelLimit(Math.max((int) Math.pow(4, (tier - GTValues.EV)) / 2, 1));
     }
 
     @Override
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityAutoChisel(metaTileEntityId, workable.getRecipeMap(), renderer, getTier(),
                 hasFrontFacing(), getTankScalingFunction());
+    }
+
+    private static class AutoChiselRecipeLogic extends SingleblockRecipeLogicNoCache {
+
+        public AutoChiselRecipeLogic(MetaTileEntity tileEntity, RecipeMap<?> recipeMap,
+                                     Supplier<IEnergyContainer> energyContainer) {
+            super(tileEntity, recipeMap, energyContainer);
+        }
     }
 }

--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/recipes/ChiselBlocksRecipe.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/recipes/ChiselBlocksRecipe.java
@@ -31,6 +31,8 @@ import com.github.gtexpert.gtmoretools.api.util.Mods;
 import com.github.gtexpert.gtmoretools.integration.chisel.ChiselConfigHolder;
 import com.github.gtexpert.gtmoretools.integration.chisel.ChiselRecipeMaps;
 import com.github.gtexpert.gtmoretools.integration.chisel.ChiselUtil;
+import team.chisel.api.carving.ICarvingGroup;
+import team.chisel.common.carving.Carving;
 
 public class ChiselBlocksRecipe {
 
@@ -47,7 +49,6 @@ public class ChiselBlocksRecipe {
                     .outputs(ModUtility.getModItem(Mods.Names.CHISEL, "bookshelf_" + bookshelf[i]))
                     .duration(100).EUt(VH[ULV])
                     .buildAndRegister();
-            registerAutoChiselRecipe("bookshelf" + bookshelf[i].toUpperCase());
         }
 
         // Material Blocks
@@ -128,8 +129,6 @@ public class ChiselBlocksRecipe {
                     ChiselUtil.addVariation("lampBorderless" + colorName, new ItemStack(lamp, 1, lampMeta));
                     lampMeta++;
                 }
-                registerAutoChiselRecipe("lamp" + colorName);
-                registerAutoChiselRecipe("lampBorderless" + colorName);
                 i++;
             }
         }
@@ -140,364 +139,30 @@ public class ChiselBlocksRecipe {
         // Material Blocks
         List<ItemStack> aluminums = OreDictionary.getOres("blockAluminum");
         aluminums.forEach(alumimun -> OreDictionary.registerOre("blockAluminium", alumimun));
-        Arrays.asList("blockAluminium", "blockBronze", "blockCharcoal", "blockCoal", "blockFuelCoke", "blockCobalt",
-                "blockCopper", "blockDiamond", "blockElectrum", "blockEmerald", "blockGold", "blockInvar", "blockIron",
-                "blockLapis", "blockLead", "blockNickel", "blockPlatinum", "blockSilver", "blockSteel", "blockTin",
-                "blockUranium").forEach(ChiselBlocksRecipe::registerAutoChiselRecipe);
-
-        // Andesite
-        registerAutoChiselRecipe("stoneAndesite");
-
-        // Antiblock
-        for (int i = 0; i < Materials.CHEMICAL_DYES.length; i++) {
-            OreDictionary.registerOre("blockAntiblock",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "antiblock", 1, i));
-        }
-        registerAutoChiselRecipe("blockAntiblock");
-
-        // Basalt
-        registerAutoChiselRecipe("stoneBasalt");
-
-        // Brick
-        for (int i = 0; i < 16; i++) {
-            OreDictionary.registerOre("blockBrick", ModUtility.getModItem(Mods.Names.CHISEL, "bricks", 1, i));
-        }
-        for (int i = 0; i < 10; i++) {
-            OreDictionary.registerOre("blockBrick", ModUtility.getModItem(Mods.Names.CHISEL, "bricks1", 1, i));
-        }
-        for (int i = 0; i < 6; i++) {
-            OreDictionary.registerOre("blockBrick", ModUtility.getModItem(Mods.Names.CHISEL, "bricks2", 1, i));
-        }
-        registerAutoChiselRecipe("blockBrick");
-
-        // Brownstone
-        for (int i = 0; i < 10; i++) {
-            OreDictionary.registerOre("blockBrownstone",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "brownstone", 1, i));
-        }
-        registerAutoChiselRecipe("blockBrownstone");
-
-        // Colored Blocks
-        for (int i = 0; i < Materials.CHEMICAL_DYES.length; i++) {
-            EnumDyeColor dyeColor = EnumDyeColor.values()[i];
-            String upperColorName = dyeColor.toString().equals("silver") ?
-                    "LightGray" : CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, dyeColor.getName());
-            String lowerColorName = dyeColor.toString().equals("silver") ?
-                    "lightgray" : dyeColor.toString().toLowerCase();
-
-            // Carpet
-            OreDictionary.registerOre("carpet" + upperColorName, new ItemStack(Blocks.CARPET, 1, i));
-            OreDictionary.registerOre("carpet" + upperColorName,
-                    ModUtility.getModItem(Mods.Names.CHISEL, "carpet_" + lowerColorName));
-            OreDictionary.registerOre("carpet" + upperColorName,
-                    ModUtility.getModItem(Mods.Names.CHISEL, "carpet_" + lowerColorName, 1, 1));
-            registerAutoChiselRecipe("carpet" + upperColorName);
-
-            // Concrete
-            OreDictionary.registerOre("blockConcrete" + upperColorName, new ItemStack(Blocks.CONCRETE, 1, i));
-            registerAutoChiselRecipe("blockConcrete" + lowerColorName);
-
-            // Stained Glass
-            OreDictionary.registerOre("blockChisellableGlass" + upperColorName,
-                    new ItemStack(Blocks.STAINED_GLASS, 1, i));
-            for (int j = 0; j < 6; j++) {
-                OreDictionary.registerOre("blockChisellableGlass" + upperColorName,
-                        ModUtility.getModItem(Mods.Names.CHISEL, "glassdyed" + lowerColorName, 1, j));
-            }
-
-            // Colorless Glass
-            registerAutoChiselRecipe("blockChisellableGlass" + upperColorName);
-            OreDictionary.registerOre("blockChisellableGlassColorless", new ItemStack(Blocks.GLASS));
-            for (int j = 0; j < 15; j++) {
-                OreDictionary.registerOre("blockChisellableGlassColorless",
-                        ModUtility.getModItem(Mods.Names.CHISEL, "glass", 1, j));
-            }
-            OreDictionary.registerOre("blockChisellableGlassColorless",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "glass1"));
-            OreDictionary.registerOre("blockChisellableGlassColorless",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "glass1", 1, 1));
-            registerAutoChiselRecipe("blockChisellableGlassColorless");
-
-            // Glass Pane
-            registerAutoChiselRecipe("paneGlass" + upperColorName);
-            registerAutoChiselRecipe("paneGlassColorless");
-
-            // Wool
-            OreDictionary.registerOre("blockWool" + upperColorName,
-                    ModUtility.getModItem(Mods.Names.CHISEL, "wool_" + lowerColorName));
-            OreDictionary.registerOre("blockWool" + upperColorName,
-                    ModUtility.getModItem(Mods.Names.CHISEL, "wool_" + lowerColorName, 1, 1));
-            registerAutoChiselRecipe("blockWool" + upperColorName);
-        }
-
-        // Certus Quartz
-        for (int i = 0; i < 16; i++) {
-            OreDictionary.registerOre("blockCertus", ModUtility.getModItem(Mods.Names.CHISEL, "certus", 1, i));
-            OreDictionary.registerOre("blockCertus", ModUtility.getModItem(Mods.Names.CHISEL, "certus1", 1, i));
-        }
-        OreDictionary.registerOre("blockCertus", ModUtility.getModItem(Mods.Names.CHISEL, "certus2"));
-        OreDictionary.registerOre("blockCertus", ModUtility.getModItem(Mods.Names.CHISEL, "certus2", 1, 1));
-        registerAutoChiselRecipe("blockCertus");
-
-        // Cloud
-        for (int i = 0; i < 5; i++) {
-            OreDictionary.registerOre("blockCloud", ModUtility.getModItem(Mods.Names.CHISEL, "cloud", 1, i));
-        }
-        registerAutoChiselRecipe("blockCloud");
-
-        // Cobblestone
-        registerAutoChiselRecipe("cobblestone");
-
-        // Moss Stone
-        OreDictionary.registerOre("blockMossy", new ItemStack(Blocks.MOSSY_COBBLESTONE));
-        registerAutoChiselRecipe("blockMossy");
-
-        // Diorite
-        registerAutoChiselRecipe("stoneDiorite");
-
-        // Dirt
-        registerAutoChiselRecipe("dirt");
-
-        // Endstone
-        OreDictionary.registerOre("endstone", new ItemStack(Blocks.END_BRICKS));
-        registerAutoChiselRecipe("endstone");
-
-        // Factory Block
-        for (int i = 0; i < 16; i++) {
-            OreDictionary.registerOre("blockFactory", ModUtility.getModItem(Mods.Names.CHISEL, "factory", 1, i));
-            OreDictionary.registerOre("blockFactory", ModUtility.getModItem(Mods.Names.CHISEL, "technical", 1, i));
-        }
-        for (int i = 0; i < 5; i++) {
-            OreDictionary.registerOre("blockFactory", ModUtility.getModItem(Mods.Names.CHISEL, "factory1", 1, i));
-            OreDictionary.registerOre("blockFactory",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "technical1", 1, i));
-        }
-        for (int i = 0; i < 9; i++) {
-            OreDictionary.registerOre("blockFactory",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "technicalnew", 1, i));
-        }
-        registerAutoChiselRecipe("blockFactory");
-
-        // Futura Block
-        for (int i = 0; i < 6; i++) {
-            OreDictionary.registerOre("blockFutura", ModUtility.getModItem(Mods.Names.CHISEL, "futura", 1, i));
-        }
-        registerAutoChiselRecipe("blockFutura");
-
-        // Glowstone
-        registerAutoChiselRecipe("glowstone");
-
-        // Granite
-        registerAutoChiselRecipe("stoneGranite");
-
-        // Terracotta
-        OreDictionary.registerOre("hardenedClay", new ItemStack(Blocks.HARDENED_CLAY));
-        registerAutoChiselRecipe("hardenedClay");
-
-        // Ice
-        registerAutoChiselRecipe("blockIce");
-
-        // Iron Bars
-        for (int i = 0; i < 13; i++) {
-            OreDictionary.registerOre("barsIron", ModUtility.getModItem(Mods.Names.CHISEL, "ironpane", 1, i));
-        }
-        registerAutoChiselRecipe("barsIron");
-
-        // Laboratory Block
-        for (int i = 0; i < 16; i++) {
-            OreDictionary.registerOre("blockLaboratory",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "laboratory", 1, i));
-        }
-        registerAutoChiselRecipe("blockLaboratory");
-
-        // Lavastone
-        for (int i = 0; i < 16; i++) {
-            OreDictionary.registerOre("blockLavastone",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "lavastone", 1, i));
-            OreDictionary.registerOre("blockLavastone",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "lavastone1", 1, i));
-        }
-        OreDictionary.registerOre("blockLavastone", ModUtility.getModItem(Mods.Names.CHISEL, "lavastone2"));
-        registerAutoChiselRecipe("blockLavastone");
-
-        // Limestone
-        registerAutoChiselRecipe("stoneLimestone");
-
-        // Marble
-        registerAutoChiselRecipe("stoneMarble");
-
-        // Nether Brick
-        OreDictionary.registerOre("brickNether", new ItemStack(Blocks.NETHER_BRICK));
-        for (int i = 0; i < 16; i++) {
-            OreDictionary.registerOre("brickNether",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "netherbrick", 1, i));
-        }
-        registerAutoChiselRecipe("brickNether");
-
-        // Netherrack
-        registerAutoChiselRecipe("netherrack");
-
-        // Obsidian
-        registerAutoChiselRecipe("obsidian");
-
-        // Paper Wall
-        for (int i = 0; i < 9; i++) {
-            OreDictionary.registerOre("blockPaperWall", ModUtility.getModItem(Mods.Names.CHISEL, "paper", 1, i));
-        }
-        registerAutoChiselRecipe("blockPaperWall");
-
-        // Planks
-        for (int i = 0; i < 15; i++) {
-            OreDictionary.registerOre("plankWoodOak",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "planks-oak", 1, i));
-            OreDictionary.registerOre("plankWoodSpruce",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "planks-spruce", 1, i));
-            OreDictionary.registerOre("plankWoodBirch",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "planks-birch", 1, i));
-            OreDictionary.registerOre("plankWoodJungle",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "planks-jungle", 1, i));
-            OreDictionary.registerOre("plankWoodAcacia",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "planks-acacia", 1, i));
-            OreDictionary.registerOre("plankWoodDarkOak",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "planks-dark-oak", 1, i));
-        }
-        OreDictionary.registerOre("plankWoodOak", new ItemStack(Blocks.PLANKS, 1));
-        registerAutoChiselRecipe("plankWoodOak");
-        OreDictionary.registerOre("plankWoodSpruce", new ItemStack(Blocks.PLANKS, 1, 1));
-        registerAutoChiselRecipe("plankWoodSpruce");
-        OreDictionary.registerOre("plankWoodBirch", new ItemStack(Blocks.PLANKS, 1, 2));
-        registerAutoChiselRecipe("plankWoodBirch");
-        OreDictionary.registerOre("plankWoodJungle", new ItemStack(Blocks.PLANKS, 1, 3));
-        registerAutoChiselRecipe("plankWoodJungle");
-        OreDictionary.registerOre("plankWoodAcacia", new ItemStack(Blocks.PLANKS, 1, 4));
-        registerAutoChiselRecipe("plankWoodAcacia");
-        OreDictionary.registerOre("plankWoodDarkOak", new ItemStack(Blocks.PLANKS, 1, 5));
-        registerAutoChiselRecipe("plankWoodDarkOak");
-
-        // Prismarine
-        OreDictionary.registerOre("prismarineBrick", new ItemStack(Blocks.PRISMARINE, 1, 1));
-        registerAutoChiselRecipe("prismarineBrick");
-
-        // Purpur
-        OreDictionary.registerOre("blockPurpur", new ItemStack(Blocks.PURPUR_BLOCK));
-        OreDictionary.registerOre("blockPurpur", new ItemStack(Blocks.PURPUR_PILLAR));
-        for (int i = 0; i < 16; i++) {
-            OreDictionary.registerOre("blockPurpur", ModUtility.getModItem(Mods.Names.CHISEL, "purpur", 1, i));
-        }
-        for (int i = 0; i < 10; i++) {
-            OreDictionary.registerOre("blockPurpur", ModUtility.getModItem(Mods.Names.CHISEL, "purpur1", 1, i));
-        }
-        for (int i = 0; i < 5; i++) {
-            OreDictionary.registerOre("blockPurpur", ModUtility.getModItem(Mods.Names.CHISEL, "purpur2", 1, i));
-        }
-        registerAutoChiselRecipe("blockPurpur");
-
-        // Quartz Block
-        OreDictionary.registerOre("blockQuartz", new ItemStack(Blocks.QUARTZ_BLOCK, 1, 1));
-        OreDictionary.registerOre("blockQuartz", new ItemStack(Blocks.QUARTZ_BLOCK, 1, 2));
-        registerAutoChiselRecipe("blockQuartz");
-
-        // Redstone Block
-        registerAutoChiselRecipe("blockRedstone");
-
-        // Red Sandstone
-        for (int i = 0; i < 2; i++) {
-            OreDictionary.registerOre("sandstoneRed", new ItemStack(Blocks.RED_SANDSTONE, 1, i));
-        }
-        for (int i = 0; i < 16; i++) {
-            OreDictionary.registerOre("sandstoneRed",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "sandstonered", 1, i));
-            OreDictionary.registerOre("sandstoneRed",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "sandstonered-scribbles", 1, i));
-        }
-        for (int i = 0; i < 10; i++) {
-            OreDictionary.registerOre("sandstoneRed",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "sandstonered1", 1, i));
-        }
-        for (int i = 0; i < 8; i++) {
-            OreDictionary.registerOre("sandstoneRed",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "sandstonered2", 1, i));
-        }
-        registerAutoChiselRecipe("sandstoneRed");
-
-        // Sandstone
-        for (int i = 0; i < 2; i++) {
-            OreDictionary.registerOre("sandstoneYellow", new ItemStack(Blocks.SANDSTONE, 1, i));
-        }
-        for (int i = 0; i < 16; i++) {
-            OreDictionary.registerOre("sandstoneYellow",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "sandstoneyellow", 1, i));
-            OreDictionary.registerOre("sandstoneYellow",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "sandstone-scribbles", 1, i));
-        }
-        for (int i = 0; i < 10; i++) {
-            OreDictionary.registerOre("sandstoneYellow",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "sandstoneyellow1", 1, i));
-        }
-        for (int i = 0; i < 8; i++) {
-            OreDictionary.registerOre("sandstoneYellow",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "sandstoneyellow2", 1, i));
-        }
-        registerAutoChiselRecipe("sandstoneYellow");
-
-        // Stone
-        for (int i = 0; i < 4; i++) {
-            OreDictionary.registerOre("stone", new ItemStack(Blocks.STONEBRICK, 1, i));
-        }
-        registerAutoChiselRecipe("stone");
-
-        // Temple Block
-        for (int i = 0; i < 16; i++) {
-            OreDictionary.registerOre("blockTemple", ModUtility.getModItem(Mods.Names.CHISEL, "temple", 1, i));
-            OreDictionary.registerOre("blockTemple",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "templemossy", 1, i));
-        }
-        registerAutoChiselRecipe("blockTemple");
-
-        // Tyrian
-        for (int i = 0; i < 15; i++) {
-            OreDictionary.registerOre("blockTyrian", ModUtility.getModItem(Mods.Names.CHISEL, "tyrian", 1, i));
-        }
-        registerAutoChiselRecipe("blockTyrian");
-
-        // Valentines' Block
-        for (int i = 0; i < 10; i++) {
-            OreDictionary.registerOre("blockValentine",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "valentines", 1, i));
-        }
-        registerAutoChiselRecipe("blockValentine");
-
-        // Voidstone
-        for (int i = 0; i < 8; i++) {
-            OreDictionary.registerOre("blockVoidstone",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "voidstone", 1, i));
-            OreDictionary.registerOre("blockVoidstone",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "energizedvoidstone", 1, i));
-        }
-        for (int i = 0; i < 15; i++) {
-            OreDictionary.registerOre("blockVoidstone",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "voidstonerunic", 1, i));
-        }
-        registerAutoChiselRecipe("blockVoidstone");
-
-        // Waterstone
-        for (int i = 0; i < 16; i++) {
-            OreDictionary.registerOre("blockWaterstone",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "waterstone", 1, i));
-            OreDictionary.registerOre("blockWaterstone",
-                    ModUtility.getModItem(Mods.Names.CHISEL, "waterstone1", 1, i));
-        }
-        OreDictionary.registerOre("blockWaterstone", ModUtility.getModItem(Mods.Names.CHISEL, "waterstone"));
-        registerAutoChiselRecipe("blockWaterstone");
     }
 
-    private static void registerAutoChiselRecipe(String oreDictName) {
-        List<ItemStack> targets = OreDictionary.getOres(oreDictName);
-        targets.forEach(target -> ChiselRecipeMaps.AUTO_CHISEL_RECIPES.recipeBuilder()
-                .input(oreDictName)
-                .notConsumable(target)
-                .outputs(target)
-                .duration(10).EUt(VH[ULV])
-                .buildAndRegister());
+    public static void registerAutoChiselRecipe() {
+        Carving.chisel.getSortedGroupNames().forEach(groupName -> {
+            ICarvingGroup group = Carving.chisel.getGroup(groupName);
+
+            // Safety check: skip if the group does not exist
+            if (group == null) {
+                return;
+            }
+
+            List<ItemStack> stacks = Carving.chisel.getItemsForChiseling(group);
+            stacks.stream()
+                    // Exclude ItemStack.EMPTY
+                    .filter(itemStack -> !itemStack.isEmpty())
+                    .forEach(target -> stacks.stream()
+                            // Exclude cases where input and target are the same
+                            .filter(stack -> stack != target)
+                            .forEach(stack -> ChiselRecipeMaps.AUTO_CHISEL_RECIPES.recipeBuilder()
+                                    .inputs(stack.copy())
+                                    .notConsumable(target.copy())
+                                    .outputs(target.copy())
+                                    .duration(10).EUt(VH[ULV])
+                                    .buildAndRegister()));
+        });
     }
 }

--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/recipes/ChiselBlocksRecipe.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/recipes/ChiselBlocksRecipe.java
@@ -31,6 +31,7 @@ import com.github.gtexpert.gtmoretools.api.util.Mods;
 import com.github.gtexpert.gtmoretools.integration.chisel.ChiselConfigHolder;
 import com.github.gtexpert.gtmoretools.integration.chisel.ChiselRecipeMaps;
 import com.github.gtexpert.gtmoretools.integration.chisel.ChiselUtil;
+
 import team.chisel.api.carving.ICarvingGroup;
 import team.chisel.common.carving.Carving;
 
@@ -114,9 +115,9 @@ public class ChiselBlocksRecipe {
                         if (Mods.ProjectRedIllumination.isModLoaded()) {
                             ChiselUtil.addVariation("lamp" + colorName,
                                     ModUtility.getModItem(Mods.Names.PROJECT_RED_ILLUMINATION, "lamp", 1, i));
-                        ChiselUtil.addVariation("lamp" + colorName,
-                                ModUtility.getModItem(Mods.Names.PROJECT_RED_ILLUMINATION, "lamp", 1, i + 16));
-                    }
+                            ChiselUtil.addVariation("lamp" + colorName,
+                                    ModUtility.getModItem(Mods.Names.PROJECT_RED_ILLUMINATION, "lamp", 1, i + 16));
+                        }
                         ChiselUtil.addVariation("lamp" + colorName, new ItemStack(lamp, 1, lampMeta));
                         lampMeta++;
                     }

--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/recipes/ChiselBlocksRecipe.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/recipes/ChiselBlocksRecipe.java
@@ -157,7 +157,7 @@ public class ChiselBlocksRecipe {
                     .filter(itemStack -> !itemStack.isEmpty())
                     .forEach(target -> stacks.stream()
                             // Exclude cases where input and target are the same
-                            .filter(stack -> stack != target)
+                            .filter(stack -> !stack.isItemEqual(target))
                             .forEach(stack -> ChiselRecipeMaps.AUTO_CHISEL_RECIPES.recipeBuilder()
                                     .inputs(stack.copy())
                                     .notConsumable(target.copy())

--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/recipes/ChiselBlocksRecipe.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/recipes/ChiselBlocksRecipe.java
@@ -114,9 +114,9 @@ public class ChiselBlocksRecipe {
                         if (Mods.ProjectRedIllumination.isModLoaded()) {
                             ChiselUtil.addVariation("lamp" + colorName,
                                     ModUtility.getModItem(Mods.Names.PROJECT_RED_ILLUMINATION, "lamp", 1, i));
-                        }
                         ChiselUtil.addVariation("lamp" + colorName,
                                 ModUtility.getModItem(Mods.Names.PROJECT_RED_ILLUMINATION, "lamp", 1, i + 16));
+                    }
                         ChiselUtil.addVariation("lamp" + colorName, new ItemStack(lamp, 1, lampMeta));
                         lampMeta++;
                     }

--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/tools/ChiselToolItems.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/tools/ChiselToolItems.java
@@ -12,9 +12,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import gregtech.api.GTValues;
 import gregtech.api.items.toolitem.IGTTool;
 import gregtech.api.items.toolitem.ItemGTTool;
-import gregtech.api.items.toolitem.ToolHelper;
 import gregtech.api.unification.OreDictUnifier;
-import gregtech.api.unification.material.Materials;
 
 import com.github.gtexpert.gtmoretools.api.ModValues;
 

--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/tools/ChiselToolItems.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/tools/ChiselToolItems.java
@@ -30,7 +30,8 @@ public final class ChiselToolItems {
 
     public static void init() {
         CHISEL = register(ItemGTTool.Builder.of(ModValues.MODID, "chisel")
-                .toolStats(b -> b.crafting().damagePerCraftingAction(1).cannotAttack().attackSpeed(-1.0F))
+                .toolStats(b -> b.crafting().damagePerCraftingAction(1)
+                        .cannotAttack().attackSpeed(-1.0F))
                 .oreDict("toolChisel")
                 .secondaryOreDicts("craftChisel")
                 .toolClasses("chisel")

--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/tools/ChiselToolItems.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/tools/ChiselToolItems.java
@@ -32,7 +32,7 @@ public final class ChiselToolItems {
 
     public static void init() {
         CHISEL = register(ItemGTTool.Builder.of(ModValues.MODID, "chisel")
-                .toolStats(b -> b.cannotAttack().attackSpeed(-1.0F))
+                .toolStats(b -> b.crafting().damagePerCraftingAction(1).cannotAttack().attackSpeed(-1.0F))
                 .oreDict("toolChisel")
                 .secondaryOreDicts("craftChisel")
                 .toolClasses("chisel")

--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/tools/ChiselToolItems.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/tools/ChiselToolItems.java
@@ -34,6 +34,7 @@ public final class ChiselToolItems {
         CHISEL = register(ItemGTTool.Builder.of(ModValues.MODID, "chisel")
                 .toolStats(b -> b.cannotAttack().attackSpeed(-1.0F))
                 .oreDict("toolChisel")
+                .secondaryOreDicts("craftChisel")
                 .toolClasses("chisel")
                 .build());
     }

--- a/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/tools/ChiselToolRecipeHandler.java
+++ b/src/main/java/com/github/gtexpert/gtmoretools/integration/chisel/tools/ChiselToolRecipeHandler.java
@@ -34,7 +34,7 @@ public class ChiselToolRecipeHandler {
         if (ChiselConfigHolder.hardToolRecipes) {
             ModHandler.addShapedRecipe(String.format("chisel_%s", material.getName()),
                     ChiselToolItems.CHISEL.get(material),
-                    "fPh", " S ",
+                    "fP", "Sh",
                     'P', new UnificationEntry(OrePrefix.plate, material),
                     'S', new UnificationEntry(OrePrefix.stick, Materials.Wood));
         } else {
@@ -50,7 +50,7 @@ public class ChiselToolRecipeHandler {
         if (ChiselConfigHolder.hardToolRecipes) {
             ModHandler.addShapedRecipe("chisel_flint",
                     ChiselToolItems.CHISEL.get(Materials.Flint),
-                    "fFh", " S ",
+                    "fF", "Sh",
                     'F', new UnificationEntry(OrePrefix.gem, Materials.Flint),
                     'S', new UnificationEntry(OrePrefix.stick, Materials.Wood));
         } else {

--- a/src/main/resources/assets/gtmoretools/lang/en_us.lang
+++ b/src/main/resources/assets/gtmoretools/lang/en_us.lang
@@ -1,2 +1,14 @@
 item.gt.tool.chisel.name=%s Chisel
 gt.tool.class.chisel=Chisel
+
+# singleblock
+# Auto Chisel
+gtmoretools.machine.auto_chisel.lv.name=Basic Auto Chisel
+gtmoretools.machine.auto_chisel.lv.tooltip=Your ideal, we will sculpt it./nMaterial in the left, chiseling to the right. See JEI's Chiseling page for details./n§dAuthor:§f @tier940
+gtmoretools.machine.auto_chisel.mv.name=Advanced Auto Chisel
+gtmoretools.machine.auto_chisel.mv.tooltip=Your ideal, we will sculpt it/nMaterial in the left, chiseling to the right. See JEI's Chiseling page for details./n§dAuthor:§f @tier940
+gtmoretools.machine.auto_chisel.hv.name=Advanced Auto Chisel II
+gtmoretools.machine.auto_chisel.hv.tooltip=Your ideal, we will sculpt it/nMaterial in the left, chiseling to the right. See JEI's Chiseling page for details./n§dAuthor:§f @tier940
+
+# recipemaps
+recipemap.auto_chisel.name=Auto Chisel

--- a/src/main/resources/assets/gtmoretools/lang/en_us.lang
+++ b/src/main/resources/assets/gtmoretools/lang/en_us.lang
@@ -9,6 +9,16 @@ gtmoretools.machine.auto_chisel.mv.name=Advanced Auto Chisel
 gtmoretools.machine.auto_chisel.mv.tooltip=Your ideal, we will sculpt it/nMaterial in the left, chiseling to the right. See JEI's Chiseling page for details./n§dAuthor:§f @tier940
 gtmoretools.machine.auto_chisel.hv.name=Advanced Auto Chisel II
 gtmoretools.machine.auto_chisel.hv.tooltip=Your ideal, we will sculpt it/nMaterial in the left, chiseling to the right. See JEI's Chiseling page for details./n§dAuthor:§f @tier940
+gtmoretools.machine.auto_chisel.ev.name=Advanced Auto Chisel III
+gtmoretools.machine.auto_chisel.ev.tooltip=Your ideal, we will sculpt it./nMaterial in the left, chiseling to the right. See JEI's Chiseling page for details./n§dAuthor:§f @tier940
+gtmoretools.machine.auto_chisel.iv.name=Elite Auto Chisel
+gtmoretools.machine.auto_chisel.iv.tooltip=Your ideal, we will sculpt it/nMaterial in the left, chiseling to the right. See JEI's Chiseling page for details./n§dAuthor:§f @tier940
+gtmoretools.machine.auto_chisel.luv.name=Elite Auto Chisel II
+gtmoretools.machine.auto_chisel.luv.tooltip=Your ideal, we will sculpt it/nMaterial in the left, chiseling to the right. See JEI's Chiseling page for details./n§dAuthor:§f @tier940
+gtmoretools.machine.auto_chisel.zpm.name=Elite Auto Chisel III
+gtmoretools.machine.auto_chisel.zpm.tooltip=Your ideal, we will sculpt it./nMaterial in the left, chiseling to the right. See JEI's Chiseling page for details./n§dAuthor:§f @tier940
+gtmoretools.machine.auto_chisel.uv.name=Ultimate Auto Chisel
+gtmoretools.machine.auto_chisel.uv.tooltip=Your ideal, we will sculpt it/nMaterial in the left, chiseling to the right. See JEI's Chiseling page for details./n§dAuthor:§f @tier940
 
 # recipemaps
 recipemap.auto_chisel.name=Auto Chisel

--- a/src/main/resources/assets/gtmoretools/lang/ja_jp.lang
+++ b/src/main/resources/assets/gtmoretools/lang/ja_jp.lang
@@ -9,6 +9,16 @@ gtexpert.machine.auto_chisel.mv.name=発展型自動彫刻機
 gtexpert.machine.auto_chisel.mv.tooltip=あなたの理想、彫刻します/n左が素材、右が彫刻型。詳しくはJEIのChiselingページをご覧ください。/n§d作者:§f @tier940
 gtexpert.machine.auto_chisel.hv.name=発展型自動彫刻機 II
 gtexpert.machine.auto_chisel.hv.tooltip=あなたの理想、彫刻します/n左が素材、右が彫刻型。詳しくはJEIのChiselingページをご覧ください。/n§d作者:§f @tier940
+gtexpert.machine.auto_chisel.ev.name=発展型自動彫刻機 III
+gtexpert.machine.auto_chisel.ev.tooltip=あなたの理想、彫刻します/n左が素材、右が彫刻型。詳しくはJEIのChiselingページをご覧ください。/n§d作者:§f @tier940
+gtexpert.machine.auto_chisel.iv.name=精鋭型自動彫刻機
+gtexpert.machine.auto_chisel.iv.tooltip=あなたの理想、彫刻します/n左が素材、右が彫刻型。詳しくはJEIのChiselingページをご覧ください。/n§d作者:§f @tier940
+gtexpert.machine.auto_chisel.luv.name=精鋭型自動彫刻機 II
+gtexpert.machine.auto_chisel.luv.tooltip=あなたの理想、彫刻します/n左が素材、右が彫刻型。詳しくはJEIのChiselingページをご覧ください。/n§d作者:§f @tier940
+gtexpert.machine.auto_chisel.zpm.name=精鋭型自動彫刻機 III
+gtexpert.machine.auto_chisel.zpm.tooltip=あなたの理想、彫刻します/n左が素材、右が彫刻型。詳しくはJEIのChiselingページをご覧ください。/n§d作者:§f @tier940
+gtexpert.machine.auto_chisel.uv.name=究極型自動彫刻機
+gtexpert.machine.auto_chisel.uv.tooltip=あなたの理想、彫刻します/n左が素材、右が彫刻型。詳しくはJEIのChiselingページをご覧ください。/n§d作者:§f @tier940
 
 # recipemaps
 recipemap.auto_chisel.name=自動彫刻機

--- a/src/main/resources/assets/gtmoretools/lang/ja_jp.lang
+++ b/src/main/resources/assets/gtmoretools/lang/ja_jp.lang
@@ -1,2 +1,14 @@
 item.gt.tool.chisel.name=%sのチゼル
 gt.tool.class.chisel=チゼル
+
+# singleblock
+# Auto Chisel
+gtexpert.machine.auto_chisel.lv.name=基本型自動彫刻機
+gtexpert.machine.auto_chisel.lv.tooltip=あなたの理想、彫刻します/n左が素材、右が彫刻型。詳しくはJEIのChiselingページをご覧ください。/n§d作者:§f @tier940
+gtexpert.machine.auto_chisel.mv.name=発展型自動彫刻機
+gtexpert.machine.auto_chisel.mv.tooltip=あなたの理想、彫刻します/n左が素材、右が彫刻型。詳しくはJEIのChiselingページをご覧ください。/n§d作者:§f @tier940
+gtexpert.machine.auto_chisel.hv.name=発展型自動彫刻機 II
+gtexpert.machine.auto_chisel.hv.tooltip=あなたの理想、彫刻します/n左が素材、右が彫刻型。詳しくはJEIのChiselingページをご覧ください。/n§d作者:§f @tier940
+
+# recipemaps
+recipemap.auto_chisel.name=自動彫刻機


### PR DESCRIPTION
- `ChiselBlocksRecipe.java`を大規模削減
- ProRed:Illumination非導入時のエラーを修正
- GTChiselとGTKnifeのレシピ競合を修正
- AutoChiselが作成できるようにGTChiselにOredict追加
- AutoChiselの素材にしたときに耐久値が減るように (仮で`1`減ります)
- AutoChiselのlang追加
- EV+のAutoChiselの追加
- マルチブロック化が難しいため、1tick@EV固定となるIV以上のAutoChiselをパラレル化 (これによりEV以降のすべての電圧で1tick@(tier-1)に)